### PR TITLE
Handle recursive note deletion and archive

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -75,26 +75,6 @@ const Editor = ({
 		editable: !loading,
 	});
 
-	// Update editor content when note changes (external updates only)
-	useEffect(() => {
-		if (!editor || !note) return;
-
-		const newContent = note.content;
-		const newContentString = JSON.stringify(newContent);
-
-		// Only update if content is different and we're not currently saving and editor doesn't have focus
-		const shouldUpdateForExternalChange =
-			!isSavingRef.current &&
-			!editor.isFocused &&
-			newContentString !== JSON.stringify(editor.getJSON()) &&
-			newContentString !== lastSavedContentRef.current;
-
-		if (shouldUpdateForExternalChange) {
-			editor.commands.setContent(newContent, false);
-			lastSavedContentRef.current = newContentString;
-		}
-	}, [note, editor]);
-
 	const debouncedSave = useCallback(
 		(content: JSONContent) => {
 			if (!noteId) return;

--- a/src/stores/notes.ts
+++ b/src/stores/notes.ts
@@ -1,7 +1,7 @@
 import type { JSONContent } from "@tiptap/react";
 import { create } from "zustand";
 import {
-	archiveNote,
+	archiveNote as archiveNoteFile,
 	createNote,
 	deleteNote,
 	initializeNoteDir,
@@ -156,10 +156,12 @@ export const useNoteStore = create<NoteStore>()((set, get) => ({
 	removeNote: async (noteId: string) => {
 		set({ loading: true, error: null });
 		try {
-			await deleteNote(noteId);
+			const descendants = get().getDescendants(noteId);
+			const idsToDelete = [noteId, ...descendants.map((d) => d.id)];
+			await Promise.all(idsToDelete.map((id) => deleteNote(id)));
 			set((state) => {
 				const newNotes = new Map(state.notes);
-				newNotes.delete(noteId);
+				idsToDelete.forEach((id) => newNotes.delete(id));
 				return { notes: newNotes };
 			});
 		} catch (err) {
@@ -172,10 +174,12 @@ export const useNoteStore = create<NoteStore>()((set, get) => ({
 	archiveNote: async (noteId: string) => {
 		set({ loading: true, error: null });
 		try {
-			await archiveNote(noteId);
+			const descendants = get().getDescendants(noteId);
+			const idsToArchive = [noteId, ...descendants.map((d) => d.id)];
+			await Promise.all(idsToArchive.map((id) => archiveNoteFile(id)));
 			set((state) => {
 				const newNotes = new Map(state.notes);
-				newNotes.delete(noteId);
+				idsToArchive.forEach((id) => newNotes.delete(id));
 				return { notes: newNotes };
 			});
 		} catch (err) {


### PR DESCRIPTION
## Summary
- Ensure deleting or archiving a note also processes all descendant notes
- Remove duplicate editor update effect to avoid redundant content resets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --yes @biomejs/biome check src/components/Editor.tsx src/stores/notes.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c413589b483319071bcb98a1ccd38